### PR TITLE
MDM-17052 return 0.0.0 for some incorrect UA

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ matchesUA('Mozilla/5.0 (Windows NT 10.0; rv:54.0) Gecko/20100101 Firefox/54.0', 
  - It is a good idea to update this package often so that browser definitions are upto date. 
  - It is also a good idea to add `unreleased versions` to your browserslist query, and set `ignoreMinor` and `ignorePatch` to true so that alpha / beta / canary versions of browsers are matched.
  - In case you're unable to keep this package up-to-date, you can set the `allowHigherVersions` to `true`. For all the browsers specified in your browserslist query, this will return a match if the user agent version is equal to or higher than those specified in your browserslist query. Use this with care though, since it's a wildcard, and only lightly tested.
+
+## Dev workflow
+ - create a branch from `master` branch
+ - work on something
+ - prepare a PR back into `master` branch
+ - get your PR approved
+ - bump version ([according to semver](https://semver.org/#summary)) with `yarn version --new-version <patch|minor|major>` [yarn version docs](https://yarnpkg.com/en/docs/cli/version)
+ - `push` your branch
+ - upload package into repository with `yarn publish` (Bonus info: version can only be unpublished within the first 24 hours)
+ - merge PR and delete your branch
+ - create a new branch in web-mamo and run `yarn upgrade @tvoli/browserslist-useragent`. Create web-mamo PR
+
  
  ## Further reads
  - [Smart Bundling: Shipping legacy code to only legacy browsers](https://www.smashingmagazine.com/2018/10/smart-bundling-legacy-code-browsers/) 

--- a/index.js
+++ b/index.js
@@ -23,10 +23,15 @@ const browserNameMap = {
   and_uc: 'UCAndroid',
 }
 
+function parseNumber(value) {
+  const int = parseInt(value);
+  return !value || isNaN(int) ? 0 : int;
+}
+
 function getNormalizedVersion(version = '0.0.0') {
   const [major = 0, minor = 0, patch = 0] = version.split('.').slice(0, 3);
 
-  return [major, minor, patch].join('.');
+  return [parseNumber(major), parseNumber(minor), parseNumber(patch)].join('.');
 }
 
 function resolveUserAgent(uaString) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvoli/browserslist-useragent",
-  "version": "3.1.2",
+  "version": "3.1.1",
   "description": "A utility to match a browselist query to browser user agents",
   "main": "lib/index.js",
   "repository": "https://github.com/tvoli/browserslist-useragent",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvoli/browserslist-useragent",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "A utility to match a browselist query to browser user agents",
   "main": "lib/index.js",
   "repository": "https://github.com/tvoli/browserslist-useragent",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvoli/browserslist-useragent",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "A utility to match a browselist query to browser user agents",
   "main": "lib/index.js",
   "repository": "https://github.com/tvoli/browserslist-useragent",

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -8,6 +8,9 @@ const CustomUserAgentString = {
   FACEBOOK_WEBVIEW_CHROME_ANDROID: 'Mozilla/5.0 (Linux; Android 8.0.0; LG-H930 Build/OPR1.170623.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36 [FB_IAB/Orca-Android;FBAV/189.0.0.27.99;]',
   FACEBOOK_WEBVIEW_IOS: 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12D508 [FBAN/FBIOS;FBAV/27.0.0.10.12;FBBV/8291884;FBDV/iPhone7,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/8.2;FBSS/3; FBCR/vodafoneIE;FBID/phone;FBLC/en_US;FBOP/5]',
   INVALID: 'this is an invalid user agent',
+  INCORRECT_FIREFOX_VERSION: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:x.x.x) Gecko/20041107 Firefox/x.x',
+  KINDLE: 'SendToKindle/1.0.253173.0.10 CFNetwork/1325.0.1 Darwin/21.1.0',
+  OPERA: 'Opera/2 CFNetwork/1325.0.1 Darwin/21.1.0',
 }
 
 it('normalizes queries properly', () => {
@@ -371,6 +374,24 @@ it('can deal with custom user agent', () => {
   expect(resolveUserAgent(CustomUserAgentString.INVALID))
     .toEqual({
       family: '',
+      version: '0.0.0',
+    })
+
+  expect(resolveUserAgent(CustomUserAgentString.INCORRECT_FIREFOX_VERSION))
+    .toEqual({
+      family: 'Firefox',
+      version: '0.0.0',
+    })
+
+  expect(resolveUserAgent(CustomUserAgentString.KINDLE))
+    .toEqual({
+      family: 'iOS',
+      version: '0.0.0',
+    })
+
+  expect(resolveUserAgent(CustomUserAgentString.OPERA))
+    .toEqual({
+      family: 'iOS',
       version: '0.0.0',
     })
 });


### PR DESCRIPTION
https://magine.atlassian.net/browse/MDM-17052

Fix Internal server error for next UA
x.x.0 -> Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:x.x.x) Gecko/20041107 Firefox/x.x
.0.0 -> SendToKindle/1.0.253173.0.10 CFNetwork/1325.0.1 Darwin/21.1.0
.0.0 -> Opera/2 CFNetwork/1325.0.1 Darwin/21.1.0

Now returns 0.0.0